### PR TITLE
Add Supabase env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+VITE_SUPABASE_URL=<your-supabase-url>
+VITE_SUPABASE_ANON_KEY=<your-supabase-anon-key>

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+.env

--- a/README.md
+++ b/README.md
@@ -46,12 +46,17 @@ cd eso-crafting-research-tracker
 npm install
 ```
 
-3. Start the development server:
+3. Copy the example environment file and add your Supabase credentials:
+```bash
+cp .env.example .env
+# then edit .env to include your VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY
+```
+4. Start the development server:
 ```bash
 npm run dev
 ```
 
-4. Open your browser and navigate to `http://localhost:8080`
+5. Open your browser and navigate to `http://localhost:8080`
 
 ### Building for Production
 


### PR DESCRIPTION
## Summary
- include an `.env.example` with Supabase placeholders
- mention the env file in the setup instructions
- ignore the real `.env` file

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68806c7a62248333b899c4c9237b42a8