### PR TITLE
Add Supabase sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A comprehensive Elder Scrolls Online crafting research tracker built with React,
 - **Notes System**: Add research notes for each item with modal interface
 - **Smart Search**: Filter items and traits in real-time
 - **Theme Support**: Toggle between light and dark themes (saved per profile)
-- **Data Persistence**: All data saved to localStorage with instant sync
+- **Data Persistence**: Data synced to Supabase with online persistence
 - **Responsive Design**: Works perfectly on desktop, tablet, and mobile devices
 
 ## Tech Stack
@@ -23,7 +23,7 @@ A comprehensive Elder Scrolls Online crafting research tracker built with React,
 - **Build Tool**: Vite
 - **Styling**: TailwindCSS with custom ESO-themed design system
 - **UI Components**: shadcn/ui component library
-- **State Management**: React hooks with localStorage persistence
+- **State Management**: React hooks with Supabase synchronization
 - **Icons**: Lucide React icons
 
 ## Getting Started
@@ -95,13 +95,14 @@ Click the sun/moon icon to toggle between light and dark themes. Your preference
 
 ## Data Storage
 
-All data is stored locally in your browser using localStorage. This includes:
-- Character profiles and settings
-- Research progress for all traits
-- Item notes
-- Theme preferences
+Data is now synced with a Supabase backend. The following tables are used:
 
-No data is sent to external servers, ensuring your privacy and allowing offline use.
+- `trait_progress`
+- `item_notes`
+- `bank_status`
+- `research_timers`
+
+On first login any existing localStorage data will be uploaded to Supabase and localStorage is cleared. Subsequent changes are written directly through the API so your progress is kept in sync across devices.
 
 ## Browser Compatibility
 

--- a/supabase_schema.sql
+++ b/supabase_schema.sql
@@ -1,0 +1,41 @@
+CREATE TABLE trait_progress (
+    id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+    user_id uuid REFERENCES auth.users ON DELETE CASCADE,
+    profile_id text NOT NULL,
+    section text NOT NULL,
+    item text NOT NULL,
+    trait text NOT NULL,
+    completed boolean NOT NULL DEFAULT false,
+    updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE item_notes (
+    id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+    user_id uuid REFERENCES auth.users ON DELETE CASCADE,
+    profile_id text NOT NULL,
+    section text NOT NULL,
+    item text NOT NULL,
+    note text,
+    updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE bank_status (
+    id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+    user_id uuid REFERENCES auth.users ON DELETE CASCADE,
+    profile_id text NOT NULL,
+    section text NOT NULL,
+    item text NOT NULL,
+    in_bank boolean NOT NULL DEFAULT false,
+    updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE research_timers (
+    id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+    user_id uuid REFERENCES auth.users ON DELETE CASCADE,
+    profile_id text NOT NULL,
+    section text NOT NULL,
+    item text NOT NULL,
+    trait text NOT NULL,
+    end_time timestamptz,
+    updated_at timestamptz NOT NULL DEFAULT now()
+);


### PR DESCRIPTION
## Summary
- design Supabase schema for progress and notes
- sync `ESOCraftingTracker` with Supabase instead of localStorage
- upload any existing local data to Supabase on first login
- document new Supabase sync behavior
- fix README feature list to mention Supabase

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68806d7d83e083339b9e96efb1da3668