### PR TITLE
Add crafting group metadata

### DIFF
--- a/scripts/add-group-column.sql
+++ b/scripts/add-group-column.sql
@@ -1,0 +1,12 @@
+-- Add group column to items table
+alter table items add column if not exists "group" text;
+
+-- Example data fill (update existing rows)
+update items set "group" =
+  case
+    when item_type ilike '%sword%' or item_type ilike '%axe%' or item_type ilike '%mace%' or item_type ilike '%dagger%' or item_type ilike '%maul%' or item_type ilike '%cuirass%' or item_type ilike '%gauntlet%' or item_type ilike '%greave%' or item_type ilike '%pauldron%' or item_type ilike '%helm%' or item_type ilike '%sabat%' then 'Blacksmithing'
+    when item_type ilike '%robe%' or item_type ilike '%jack%' or item_type ilike '%jerkin%' or item_type ilike '%glove%' or item_type ilike '%hat%' or item_type ilike '%belt%' or item_type ilike '%boot%' or item_type ilike '%guard%' or item_type ilike '%bracer%' or item_type ilike '%arm cop%' or item_type ilike '%helmets%' or item_type ilike '%shoulder%' then 'Clothing'
+    when item_type ilike '%bow%' or item_type ilike '%staff%' or item_type ilike '%shield%' then 'Woodworking'
+    when item_type ilike '%ring%' or item_type ilike '%necklace%' then 'Jewelry'
+    else 'Other'
+  end;

--- a/src/components/TraitGrid.tsx
+++ b/src/components/TraitGrid.tsx
@@ -6,6 +6,7 @@ type Row = {
   id: string;
   item_type: string;
   trait: string;
+  group: string;
   character_items: {
     id?: string;
     completed?: boolean;

--- a/src/components/TraitGridGrouped.tsx
+++ b/src/components/TraitGridGrouped.tsx
@@ -6,6 +6,7 @@ type Row = {
   id: string;
   item_type: string;
   trait: string;
+  group: string;
   character_items: {
     completed?: boolean;
     in_bank?: boolean;
@@ -15,20 +16,16 @@ type Row = {
 
 type GroupName = "Blacksmithing" | "Clothing" | "Woodworking" | "Jewelry" | "Other";
 
-function craftGroup(itemType: string): GroupName {
-  const t = itemType.toLowerCase();
-  if (
-    ["axe","sword","dagger","mace","maul","greatsword","battle axe","arm cops","boots","bracers","cuirass","gauntlets","greaves","helm","pauldron","sabatons","girdle","vambraces","helmets","shoulders"].some(k => t.includes(k))
-  ) return "Blacksmithing";
-  if (
-    ["robe","jerkin","gloves","hat","pants","shoes","jack","belt","guards","arm cops","bracers","cuirass"].some(k => t.includes(k)) ||
-    ["arm cops","boots","bracers","cuirass","gloves","helm","jack","legs","robe","sabaton","shoes","shoulders","belt","girdle","sash"].some(k=>t.includes(k))
-  ) return "Clothing";
-  if (
-    ["bow","shield","inferno staff","ice staff","lightning staff","restoration staff","flame staff","frost staff","shock staff","staff"].some(k => t.includes(k))
-  ) return "Woodworking";
-  if (["ring","necklace"].some(k => t.includes(k))) return "Jewelry";
-  return "Other";
+function craftGroup(group: string): GroupName {
+  switch (group) {
+    case "Blacksmithing":
+    case "Clothing":
+    case "Woodworking":
+    case "Jewelry":
+      return group;
+    default:
+      return "Other";
+  }
 }
 
 export default function TraitGridGrouped({ characterId }: { characterId: string }) {
@@ -53,7 +50,7 @@ export default function TraitGridGrouped({ characterId }: { characterId: string 
 
   // Group
   const groups: Record<GroupName, Row[]> = { Blacksmithing: [], Clothing: [], Woodworking: [], Jewelry: [], Other: [] };
-  rows.forEach(r => groups[craftGroup(r.item_type)].push(r));
+  rows.forEach(r => groups[craftGroup(r.group)].push(r));
 
   const tableStyle: React.CSSProperties = { margin: "0 auto", borderCollapse: "collapse", width: "95%", maxWidth: 1100 };
   const thTd: React.CSSProperties = { borderBottom: "1px solid #333", padding: "6px 8px" };

--- a/src/lib/fetchCharacterItems.ts
+++ b/src/lib/fetchCharacterItems.ts
@@ -4,6 +4,7 @@ type Item = {
   id: string;
   item_type: string;
   trait: string;
+  group: string;
 };
 type State = {
   item_id: string;
@@ -16,7 +17,7 @@ export async function fetchCharacterItems(characterId: string) {
   // 1) All items (static list)
   const { data: items, error: itemsErr } = await supabase
     .from<Item>("items")
-    .select("id,item_type,trait")
+    .select("id,item_type,trait,group")
     .order("item_type", { ascending: true })
     .order("trait", { ascending: true });
   if (itemsErr) throw itemsErr;


### PR DESCRIPTION
## Summary
- store crafting group on `items`
- expose `group` via `fetchCharacterItems`
- group rows in `TraitGridGrouped` using metadata
- example SQL to populate new column

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688077be01d08333ac8131741e72c2c9