### PR TITLE
Add onboarding tour and improve accessibility

### DIFF
--- a/src/components/ESOCraftingTracker.tsx
+++ b/src/components/ESOCraftingTracker.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { ProfileManager } from './ProfileManager';
 import { Controls } from './Controls';
 import { CraftingTable } from './CraftingTable';
+import { FirstRunTour } from './FirstRunTour';
 import { Profile, TraitProgress, ItemNote, ItemBankStatus, ResearchTimer, AppState } from '../types';
 import { CRAFTING_DATA } from '../data/craftingData';
 import { supabase } from '@/lib/supabaseClient';
@@ -33,6 +34,7 @@ export function ESOCraftingTracker() {
   const [searchQuery, setSearchQuery] = useState('');
   const [loading, setLoading] = useState(true);
   const [userId, setUserId] = useState<string | null>(null);
+  const [showFirstRun, setShowFirstRun] = useState(false);
   const { toast } = useToast();
 
   useEffect(() => {
@@ -139,6 +141,12 @@ export function ESOCraftingTracker() {
       profiles: [...prev.profiles, newProfile],
       currentProfileId: newProfile.id
     }));
+
+    const tutorialKey = `tutorial_${newProfile.id}`;
+    if (!localStorage.getItem(tutorialKey)) {
+      setShowFirstRun(true);
+      localStorage.setItem(tutorialKey, 'shown');
+    }
   };
 
   const handleProfileSelect = (profileId: string) => {
@@ -498,6 +506,7 @@ export function ESOCraftingTracker() {
           </div>
         )}
       </div>
+      <FirstRunTour open={showFirstRun} onClose={() => setShowFirstRun(false)} />
     </div>
   );
 }

--- a/src/components/FirstRunTour.tsx
+++ b/src/components/FirstRunTour.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from './ui/dialog';
+import { Button } from './ui/button';
+
+interface FirstRunTourProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export function FirstRunTour({ open, onClose }: FirstRunTourProps) {
+  return (
+    <Dialog open={open} onOpenChange={(o) => { if (!o) onClose(); }}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Getting Started</DialogTitle>
+        </DialogHeader>
+        <ul className="list-disc pl-4 space-y-2 text-sm text-muted-foreground">
+          <li>Use the search box to quickly find items and traits.</li>
+          <li>Click the trait checkboxes to mark research progress.</li>
+          <li>Open the note icon to add notes and set research timers.</li>
+        </ul>
+        <DialogFooter>
+          <Button onClick={onClose}>Got it!</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/SubsectionTable.tsx
+++ b/src/components/SubsectionTable.tsx
@@ -270,6 +270,9 @@ export function SubsectionTable({
                             isTraitCompleted(item.name, trait) ? 'checked' : 'unchecked'
                           }`}
                           title={`${trait} - ${isTraitCompleted(item.name, trait) ? 'Completed' : 'Not researched'}`}
+                          role="checkbox"
+                          aria-checked={isTraitCompleted(item.name, trait)}
+                          aria-label={`${trait} for ${item.name}`}
                         >
                           {isTraitCompleted(item.name, trait) && (
                             <Check className="w-4 h-4 text-green-700" />

--- a/src/index.css
+++ b/src/index.css
@@ -118,7 +118,7 @@
 @layer components {
   /* ESO Crafting Components */
   .trait-checkbox {
-    @apply w-6 h-6 rounded border-2 border-border transition-all duration-200 cursor-pointer flex items-center justify-center hover:scale-105;
+    @apply w-6 h-6 rounded border-2 border-border transition-all duration-200 cursor-pointer flex items-center justify-center hover:scale-105 focus:outline-none focus:ring-2 focus:ring-ring;
   }
   
   .trait-checkbox.unchecked {
@@ -130,11 +130,11 @@
   }
   
   .dark .trait-checkbox.unchecked {
-    @apply bg-red-900/30 border-red-700 hover:bg-red-800/40;
+    @apply bg-red-900 border-red-700 hover:bg-red-800;
   }
-  
+
   .dark .trait-checkbox.checked {
-    @apply bg-green-900/30 border-green-700 hover:bg-green-800/40;
+    @apply bg-green-900 border-green-700 hover:bg-green-800;
   }
   
   .progress-bar {

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -36,7 +36,7 @@ export default function Login() {
       <h2>{mode === "signup" ? "Create account" : "Sign in"}</h2>
       <form onSubmit={handleSubmit}>
         <label>Email<br/>
-          <input value={email} onChange={e=>setEmail(e.target.value)} type="email" required />
+          <input value={email} onChange={e=>setEmail(e.target.value)} type="email" required autoFocus />
         </label><br/><br/>
         <label>Password<br/>
           <input value={pw} onChange={e=>setPw(e.target.value)} type="password" required />


### PR DESCRIPTION
## Summary
- launch a short tutorial dialog when a new profile is created
- update checkbox styles for better contrast and keyboard focus
- expose trait checkboxes to assistive tech via ARIA
- autofocus the email field in the login form

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68807a266cec8333967018029118bef6